### PR TITLE
Redesign table component

### DIFF
--- a/client/src/components/DistrictPage.tsx
+++ b/client/src/components/DistrictPage.tsx
@@ -74,11 +74,8 @@ const DistrictPage = (props: any) => {
                                 direction="column"
                                 alignItems="center"
                                 justifyContent="space-between">
-                                <Grid item xs={12}>
-                                    <Typography className={classes.headerSm} align="center" variant="subtitle1">Общее кол-во проголосовавших по УИКам</Typography>
-                                </Grid>
                                 <Grid xs={12} item>
-                                    <TableComponent tikNum={props.match.params.id} uiks={data?.data?.data?.summary_data} status={status} history={props.history} />
+                                    <TableComponent tikNum={props.match.params.id} uiks={data?.data?.data?.summary_data} status={status} history={props.history} caption="Общее кол-во проголосовавших по УИКам"/>
                                 </Grid>
                             </Grid>
                         </Card>

--- a/client/src/components/LandingPage.tsx
+++ b/client/src/components/LandingPage.tsx
@@ -128,11 +128,8 @@ const LandingPage = (props: any) => {
                                 direction="column"
                                 alignItems="center"
                                 justifyContent="space-between">
-                                <Grid item xs={12}>
-                                    <Typography className={classes.headerSm} align="center" variant="subtitle1">Общее кол-во проголосовавших по ТИКам</Typography>
-                                </Grid>
                                 <Grid xs={12} item>
-                                    <TableComponent districts={data?.data?.districts} status={status} history={props.history} />
+                                    <TableComponent districts={data?.data?.districts} status={status} history={props.history} caption="Общее кол-во проголосовавших по ТИКам"/>
                                 </Grid>
                             </Grid>
                         </Card>

--- a/client/src/components/PollingPage.tsx
+++ b/client/src/components/PollingPage.tsx
@@ -82,11 +82,8 @@ const PollingPage = (props: any) => {
                                 direction="column"
                                 alignItems="center"
                                 justifyContent="space-between">
-                                <Grid item xs={12}>
-                                    <Typography className={classes.headerSm} align="center" variant="subtitle1">Список нарушений</Typography>
-                                </Grid>
                                 <Grid xs={12} item>
-                                    <TableComponent issues={data?.data?.data?.issues} status={status} history={props.history} />
+                                    <TableComponent issues={data?.data?.data?.issues} status={status} history={props.history} caption="Список нарушений"/>
                                 </Grid>
                             </Grid>
                         </Card>

--- a/client/src/components/TableComponent.tsx
+++ b/client/src/components/TableComponent.tsx
@@ -24,12 +24,14 @@ const TableComponent = (props: any) => {
                         <col span={1} style={{width: '50%'}} />
                         <col span={1} style={{width: '25%'}} />
                     </colgroup>
-                    : props.issues
+                    : props.issues && props.issues.length > 0
                         ? <colgroup>
                             <col span={1} style={{width: '20%'}} />
                             <col span={1} style={{width: '75%'}} />
                         </colgroup>
-                        : null}
+                        : <colgroup>
+                            <col span={1} style={{width: '100%'}} />
+                        </colgroup>}
             {props.districts 
                 ? <tr>
                     <th>ТИК</th>

--- a/client/src/components/TableComponent.tsx
+++ b/client/src/components/TableComponent.tsx
@@ -32,6 +32,7 @@ const TableComponent = (props: any) => {
                         : <colgroup>
                             <col span={1} style={{width: '100%'}} />
                         </colgroup>}
+            <thead>
             {props.districts 
                 ? <tr>
                     <th>ТИК</th>
@@ -48,7 +49,9 @@ const TableComponent = (props: any) => {
                             <th>дата</th>
                             <th>описание</th>
                         </tr> 
-                        : <p>Нарушений не зафиксировано</p>}
+                        : <tr><td>Нарушений не зафиксировано</td></tr>}
+            </thead>
+            <tbody>
             {props.districts 
                 ? props.districts.map((dist: any) => {return(
                 <tr className="issue-table__row_clickable" onClick={() => {props.history.push(`/tk/${dist.tiknum}`)}} key={dist.tiknum}>
@@ -70,7 +73,8 @@ const TableComponent = (props: any) => {
                             <td><span>{format(parseISO(issue.registered_time), "yyyy:MM:dd, HH:mm:ss")}</span></td>
                             <td><span>{issue.description}</span></td>
                         </tr>)})
-                        : <p>{props.status}</p>}
+                        : <tr><td>{props.status}</td></tr>}
+            </tbody>
         </table>
     )
 }

--- a/client/src/components/TableComponent.tsx
+++ b/client/src/components/TableComponent.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { TableContainer, Table, TableHead, TableRow, TableCell } from '@material-ui/core';
-import { useStyles } from '../styles/CustomStyles'
 import { format, parseISO } from 'date-fns';
 import '../styles/table.css'
 
@@ -12,63 +10,66 @@ const TableComponent = (props: any) => {
             setWidth(window.innerWidth)
         })
     }, [])
-    const classes = useStyles();
     return (
-        <TableContainer>
-            <Table className={classes.table} size="medium" aria-label="simple table" padding={767 > width && props.history.location.pathname !== '/uik/:id' ? "none" : "normal"} >
-                <TableHead>
-                    {props.districts ? <TableRow  >
-                        <TableCell align="center">
-                            <p>   ТИК</p>
-                        </TableCell>
-                        <TableCell align="center">
-                            <p>голоса:<b>НП</b>/<span className="italic">официально</span></p>
-                        </TableCell>
-                    </TableRow> : props.uiks ? <TableRow> <TableCell align="center">
-                        <p>УИК</p>
-                    </TableCell>
-                        <TableCell align="center">
-                            <p>Адрес</p>
-                        </TableCell>
-                        <TableCell align="center">
-                            <p>голоса:<b> НП</b>/<span className="italic">официально</span></p>
-                        </TableCell>
-                    </TableRow> : props.issues && props.issues.length > 0 ? <TableRow  >
-                        <TableCell align="center">
-                            Время
-                        </TableCell>
-                        <TableCell align="center">
-                            Описание нарушения
-                        </TableCell>
-                    </TableRow> : <p>Нарушений не зафиксировано</p>}
-                </TableHead>
-                {props.districts ? props.districts.map((dist: any) => {
-                    return <TableRow className={classes.hoverEffect} onClick={() => {
-                        props.history.push(`/tk/${dist.tiknum}`)
-                    }} key={dist.tiknum}>
-                        <TableCell align="left"><p className="cell underline">{dist.tik_name}</p></TableCell>
-                        <TableCell align="left"><p className="cell"><b>{dist.votes}</b>/<span className="italic">{dist.official ? dist.official : "—"}</span></p></TableCell>
-                    </TableRow>
-                }) : props.uiks ? props.uiks.map((uik: any) => {
-                    const shortAddress = uik.address.split(',').slice(3,).join()
-                    return <TableRow className={classes.hoverEffect} onClick={() => {
-                        props.history.push(`/uik/${props.tikNum}/${uik.uik_id}`)
-                    }} key={uik.uik_id}>
-                        <TableCell align="left"><p className="cell underline">УИК№{uik.uik_id}</p></TableCell>
-                        <TableCell align="left"><p className="cell underline">{shortAddress}</p></TableCell>
-                        <TableCell align="left"><p className="cell"><b>{uik.votes_amount}</b>/<span className="italic">{uik.official ? uik.official : "—"}</span></p></TableCell>
-
-                    </TableRow>
-                }) : props.issues ? props.issues.map((issue: any) => {
-                    return <TableRow key={issue.registered_time}>
-                        <TableCell align="left"><p className="cell">{format(parseISO(issue.registered_time), "dd:MM, HH")}</p></TableCell>
-                        <TableCell align="left"><p className="cell">{issue.description}</p></TableCell>
-                    </TableRow>
-                }) : <p>{props.status}</p>
-
-                }
-            </Table>
-        </TableContainer>
+        <table className='issue-table'>
+            <caption>{props.caption}</caption>
+            {props.districts
+                ? <colgroup>
+                    <col span={1} style={{width: '50%'}} />
+                    <col span={1} style={{width: '50%'}} />
+                </colgroup>
+                : props.uiks
+                    ? <colgroup>
+                        <col span={1} style={{width: '25%'}} />
+                        <col span={1} style={{width: '50%'}} />
+                        <col span={1} style={{width: '25%'}} />
+                    </colgroup>
+                    : props.issues
+                        ? <colgroup>
+                            <col span={1} style={{width: '20%'}} />
+                            <col span={1} style={{width: '75%'}} />
+                        </colgroup>
+                        : null}
+            {props.districts 
+                ? <tr>
+                    <th>ТИК</th>
+                    <th>голоса: НП/официально</th>
+                </tr> 
+                : props.uiks 
+                    ? <tr>
+                        <th>УИК</th>
+                        <th>адрес</th>
+                        <th>голоса</th>
+                    </tr> 
+                    : props.issues && props.issues.length > 0 
+                        ? <tr>
+                            <th>дата</th>
+                            <th>описание</th>
+                        </tr> 
+                        : <p>Нарушений не зафиксировано</p>}
+            {props.districts 
+                ? props.districts.map((dist: any) => {return(
+                <tr className="issue-table__row_clickable" onClick={() => {props.history.push(`/tk/${dist.tiknum}`)}} key={dist.tiknum}>
+                    <td><span>{dist.tik_name}</span></td>
+                    <td><span>{dist.votes}&nbsp;/ {dist.official ? dist.official : "—"}</span></td>
+                </tr>)})
+                : props.uiks
+                    ? props.uiks.map((uik: any) => {
+                        const shortAddress = uik.address.split(',').slice(3,).join()
+                        return (
+                        <tr className="issue-table__row_clickable" onClick={() => {props.history.push(`/uik/${props.tikNum}/${uik.uik_id}`)}} key={uik.uik_id}>
+                           <td><span>УИК №{uik.uik_id}</span></td> 
+                           <td><span>{shortAddress}</span></td> 
+                           <td><span>{uik.votes_amount}&nbsp;/ {uik.official ? uik.official : "—"}</span></td> 
+                        </tr>)})
+                    : props.issues
+                        ? props.issues.map((issue: any) => {return (
+                        <tr key={issue.registered_time}>
+                            <td><span>{format(parseISO(issue.registered_time), "yyyy:MM:dd, HH:mm:ss")}</span></td>
+                            <td><span>{issue.description}</span></td>
+                        </tr>)})
+                        : <p>{props.status}</p>}
+        </table>
     )
 }
 

--- a/client/src/styles/table.css
+++ b/client/src/styles/table.css
@@ -49,6 +49,7 @@
     justify-content: center;
     align-items: center;
     margin: 7px 17px;
+    text-align: center;
 }
 
 @media screen and (max-width: 768px) {

--- a/client/src/styles/table.css
+++ b/client/src/styles/table.css
@@ -26,8 +26,12 @@
     letter-spacing: 0.025em;
 }
 
-.issue-table__row_clickable {
+.issue-table__row_clickable:hover {
     cursor: pointer;
+}
+
+.issue-table__row_clickable:hover td span{
+    background: #e3e3e3;
 }
 
 .issue-table th {

--- a/client/src/styles/table.css
+++ b/client/src/styles/table.css
@@ -16,6 +16,7 @@
     line-height: 22px;
     letter-spacing: 0.025em;
     color: #565454;
+    margin: 10px 0 52px;
 }
 
 .issue-table caption {
@@ -53,6 +54,10 @@
 }
 
 @media screen and (max-width: 768px) {
+    .issue-table {
+        margin: 10px 0 26px;
+    }
+
     .issue-table caption {
         font-size: 14px;
         line-height: 17px;

--- a/client/src/styles/table.css
+++ b/client/src/styles/table.css
@@ -9,3 +9,63 @@
     padding-left: 8px;
     padding-bottom: 6px;
 }
+
+.issue-table {
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 22px;
+    letter-spacing: 0.025em;
+    color: #565454;
+}
+
+.issue-table caption {
+    margin: 20px auto 40px auto;
+    font-weight: bold;
+    font-size: 24px;
+    line-height: 29px;
+    letter-spacing: 0.025em;
+}
+
+.issue-table__row_clickable {
+    cursor: pointer;
+}
+
+.issue-table th {
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 22px;
+    padding-bottom: 22px;
+}
+
+.issue-table td span {
+    display: flex;
+    height: 78px;
+    background: #F3F1F1;
+    padding: 10px;
+    justify-content: center;
+    align-items: center;
+    margin: 7px 17px;
+}
+
+@media screen and (max-width: 768px) {
+    .issue-table caption {
+        font-size: 14px;
+        line-height: 17px;
+        text-align: center;
+    }
+
+    .issue-table th {
+        font-weight: 600;
+        font-size: 12px;
+        line-height: 15px;
+        text-align: center;
+        padding-bottom: 15px;
+    }
+
+    .issue-table td span {
+        margin: 2px 5px;
+        font-size: 12px;
+        line-height: 15px;
+        height: 56px;
+    }
+}


### PR DESCRIPTION
Переверстал компонент таблицы. Нет нужды использовать Matrial Ui, их только дольше перевёрстывать.
Заголовок для таблицы перенёс внутрь компонента таблицы через пропсы, чтобы было семантически более верно (надеюсь, это норм)